### PR TITLE
Fix technician role inbox functionality

### DIFF
--- a/handlers/technician/inbox.py
+++ b/handlers/technician/inbox.py
@@ -266,7 +266,8 @@ def get_technician_inbox_router():
             # Store applications in state
             await state.update_data(
                 applications=applications,
-                current_app_index=0
+                current_app_index=0,
+                lang=lang
             )
             
             # Show first application
@@ -436,6 +437,8 @@ def get_technician_inbox_router():
             data = await state.get_data()
             current_index = data.get('current_app_index', 0)
             applications = data.get('applications', [])
+            # Retrieve user language (default to 'uz' if not found)
+            lang = await get_user_lang(callback.from_user.id)
             
             if not applications or current_index >= len(applications):
                 await callback.answer("Ariza topilmadi")
@@ -480,6 +483,8 @@ def get_technician_inbox_router():
             data = await state.get_data()
             current_index = data.get('current_app_index', 0)
             applications = data.get('applications', [])
+            # Retrieve user language
+            lang = await get_user_lang(callback.from_user.id)
             
             if not applications or current_index >= len(applications):
                 await callback.answer("Ariza topilmadi")
@@ -527,6 +532,8 @@ def get_technician_inbox_router():
         try:
             # Get the diagnostic text
             diagnostic_text = message.text.strip()
+            # Retrieve user language
+            lang = await get_user_lang(message.from_user.id)
             
             if len(diagnostic_text) < 10:
                 await message.answer(
@@ -643,6 +650,8 @@ def get_technician_inbox_router():
         """Handle warehouse item selection"""
         try:
             await callback.answer()
+            # Retrieve user language
+            lang = await get_user_lang(callback.from_user.id)
             
             item_id = int(callback.data.replace("tech_select_item_", ""))
             
@@ -773,6 +782,8 @@ def get_technician_inbox_router():
         """Handle custom warehouse item input"""
         try:
             await callback.answer()
+            # Retrieve user language
+            lang = await get_user_lang(callback.from_user.id)
             
             # Get application data from state
             data = await state.get_data()
@@ -880,6 +891,8 @@ def get_technician_inbox_router():
         """Handle warehouse no choice"""
         try:
             await callback.answer()
+            # Retrieve user language
+            lang = await get_user_lang(callback.from_user.id)
             
             # Get application data from state
             data = await state.get_data()
@@ -913,6 +926,8 @@ def get_technician_inbox_router():
         """Handle complete work button"""
         try:
             await callback.answer()
+            # Retrieve user language
+            lang = await get_user_lang(callback.from_user.id)
             
             # Get current application
             data = await state.get_data()


### PR DESCRIPTION
Fixes technician role inbox functionality by ensuring the `lang` variable is correctly defined and passed to keyboard functions.

The inbox for the technician role was failing because the `lang` variable was undefined in several callback handlers, which prevented the keyboards from being rendered correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-3100726a-dacb-4701-9be4-235b73fc25ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3100726a-dacb-4701-9be4-235b73fc25ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

