### PR TITLE
Fix callback parsing and business type mapping

### DIFF
--- a/handlers/controller/orders.py
+++ b/handlers/controller/orders.py
@@ -489,19 +489,25 @@ def get_controller_orders_router():
     @router.callback_query(lambda c: c.data.startswith("ctrl_orders_nav_prev_"))
     async def orders_nav_prev(callback: CallbackQuery, state: FSMContext):
         await callback.answer()
-        _, _, _, flt, index = callback.data.split("_")
+        parts = callback.data.split("_")
+        flt = parts[4]
+        index = parts[5]
         await _render_order_detail(callback, flt=flt, index=int(index))
 
     @router.callback_query(lambda c: c.data.startswith("ctrl_orders_nav_next_"))
     async def orders_nav_next(callback: CallbackQuery, state: FSMContext):
         await callback.answer()
-        _, _, _, flt, index = callback.data.split("_")
+        parts = callback.data.split("_")
+        flt = parts[4]
+        index = parts[5]
         await _render_order_detail(callback, flt=flt, index=int(index))
 
     @router.callback_query(lambda c: c.data.startswith("ctrl_orders_refresh_detail_"))
     async def orders_refresh_detail(callback: CallbackQuery, state: FSMContext):
         await callback.answer()
-        _, _, _, flt, index = callback.data.split("_")
+        parts = callback.data.split("_")
+        flt = parts[4]
+        index = parts[5]
         await _render_order_detail(callback, flt=flt, index=int(index))
 
     @router.callback_query(lambda c: c.data.startswith("ctrl_orders_view_"))

--- a/handlers/controller/technicians.py
+++ b/handlers/controller/technicians.py
@@ -176,19 +176,25 @@ def get_controller_technicians_router():
     @router.callback_query(lambda c: c.data.startswith('ctrl_tech_nav_prev_'))
     async def tech_nav_prev(callback: CallbackQuery, state: FSMContext):
         await callback.answer()
-        _, _, _, flt, index = callback.data.split('_')
+        parts = callback.data.split('_')
+        flt = parts[4]
+        index = parts[5]
         await _render_tech_detail(callback, flt=flt, index=int(index))
 
     @router.callback_query(lambda c: c.data.startswith('ctrl_tech_nav_next_'))
     async def tech_nav_next(callback: CallbackQuery, state: FSMContext):
         await callback.answer()
-        _, _, _, flt, index = callback.data.split('_')
+        parts = callback.data.split('_')
+        flt = parts[4]
+        index = parts[5]
         await _render_tech_detail(callback, flt=flt, index=int(index))
 
     @router.callback_query(lambda c: c.data.startswith('ctrl_tech_refresh_detail_'))
     async def tech_refresh_detail(callback: CallbackQuery, state: FSMContext):
         await callback.answer()
-        _, _, _, flt, index = callback.data.split('_')
+        parts = callback.data.split('_')
+        flt = parts[4]
+        index = parts[5]
         await _render_tech_detail(callback, flt=flt, index=int(index))
 
     return router

--- a/keyboards/controllers_buttons.py
+++ b/keyboards/controllers_buttons.py
@@ -65,8 +65,8 @@ def controller_zayavka_type_keyboard(lang: str = 'uz') -> InlineKeyboardMarkup:
 
     keyboard = InlineKeyboardMarkup(
         inline_keyboard=[
-            [InlineKeyboardButton(text=person_physical_text, callback_data="ctrl_zayavka_type_b2b")],
-            [InlineKeyboardButton(text=person_legal_text, callback_data="ctrl_zayavka_type_b2c")]
+            [InlineKeyboardButton(text=person_physical_text, callback_data="ctrl_zayavka_type_b2c")],
+            [InlineKeyboardButton(text=person_legal_text, callback_data="ctrl_zayavka_type_b2b")]
         ]
     )
     return keyboard


### PR DESCRIPTION
Fixes `ValueError` in callback data parsing for order/technician navigation and refresh, and corrects reversed B2B/B2C callback mapping.

The callback data strings contained 6 parts when split by underscores, but the previous code attempted to unpack them into only 5 variables, causing a `ValueError`. This PR updates the parsing to correctly extract `flt` and `index` from the 6-part string. It also corrects the swapped B2B/B2C callback data for physical and legal persons.

---
<a href="https://cursor.com/background-agent?bcId=bc-1396b12b-e6b3-412e-9cb2-dd91a4f1246f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1396b12b-e6b3-412e-9cb2-dd91a4f1246f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

