### PR TITLE
Fix race condition in user creation

### DIFF
--- a/database/clients/queries.py
+++ b/database/clients/queries.py
@@ -12,44 +12,32 @@ from .db import get_pool
 async def ensure_global_user(telegram_id: int, full_name: str = None, username: str = None,
                              phone: str = None, language: str = "uz", address: str = None,
                              abonent_id: str = None) -> int:
-	"""Upsert client by telegram_id and return id.
+	"""Upsert client by telegram_id atomically and return id.
 	
-	This implementation performs a manual SELECT-then-UPDATE/INSERT sequence
-	to avoid requiring a unique constraint on telegram_id.
+	Uses a single INSERT ... ON CONFLICT DO UPDATE to avoid race conditions.
+	Requires a UNIQUE constraint on telegram_id (present in migrations).
 	"""
 	pool = await get_pool()
 	async with pool.acquire() as conn:
-		# Check if user exists
-		row = await conn.fetchrow("SELECT id FROM users WHERE telegram_id = $1 LIMIT 1", telegram_id)
-		if row:
-			# Update existing
-			row = await conn.fetchrow(
-				"""
-				UPDATE users
-				SET full_name = $2,
-					username = $3,
-					phone    = $4,
-					language = $5,
-					address  = $6,
-					abonent_id = $7,
-					updated_at = NOW()
-				WHERE telegram_id = $1
-				RETURNING id
-				""",
-				telegram_id, full_name, username, phone, language, address, abonent_id,
+		row = await conn.fetchrow(
+			"""
+			INSERT INTO users(
+				telegram_id, full_name, username, phone, language, is_active, address, abonent_id, created_at, updated_at
 			)
-			return int(row["id"]) if row else -1
-		else:
-			# Insert new
-			row = await conn.fetchrow(
-				"""
-				INSERT INTO users(telegram_id, full_name, username, phone, language, is_active, address, abonent_id, created_at, updated_at)
-				VALUES ($1, $2, $3, $4, $5, true, $6, $7, NOW(), NOW())
-				RETURNING id
-				""",
-				telegram_id, full_name, username, phone, language, address, abonent_id,
-			)
-			return int(row["id"]) if row else -1
+			VALUES ($1, $2, $3, $4, $5, true, $6, $7, NOW(), NOW())
+			ON CONFLICT (telegram_id) DO UPDATE SET
+				full_name  = EXCLUDED.full_name,
+				username   = EXCLUDED.username,
+				phone      = EXCLUDED.phone,
+				language   = EXCLUDED.language,
+				address    = EXCLUDED.address,
+				abonent_id = EXCLUDED.abonent_id,
+				updated_at = NOW()
+			RETURNING id
+			""",
+			telegram_id, full_name, username, phone, language, address, abonent_id,
+		)
+		return int(row["id"]) if row else -1
 
 
 async def get_by_telegram_id(telegram_id: int) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
Refactor `ensure_global_user` to use an atomic upsert, preventing race conditions during user creation.

---
<a href="https://cursor.com/background-agent?bcId=bc-9610026c-31da-4b9d-94e1-5d29cbb2dfec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9610026c-31da-4b9d-94e1-5d29cbb2dfec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

